### PR TITLE
fix: api base url

### DIFF
--- a/lacale-api.yml
+++ b/lacale-api.yml
@@ -7,7 +7,7 @@ type: private
 encoding: UTF-8
 
 links:
-  - https://la-cale.space/api/external
+  - https://la-cale.space
 
 caps:
   categorymappings:

--- a/lacale-api.yml
+++ b/lacale-api.yml
@@ -7,7 +7,7 @@ type: private
 encoding: UTF-8
 
 links:
-  - https://la-cale.space
+  - https://la-cale.space/
 
 caps:
   categorymappings:


### PR DESCRIPTION
By default prowlarr would add an /api/ resulting in request with https://la-cale.space/api/api/external

this will fix it