### PR TITLE
Fix #29 && #26: option multilang + filtre CJK “safe” pour éviter les résultats hors sujet

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -296,7 +296,7 @@ The site may use Cloudflare protection. If you experience issues:
 
 ### Prowlarr/Jackett
 
-Use the provided indexer definition: `lacale-api.yml`
+Use the provided indexer definition: `lacale-api-custom.yml`
 
 **Magnet Support**: The indexer includes both `.torrent` download links and magnet links. To use magnets:
 1. Go to **Settings → Indexers** in Prowlarr

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ When adding new categories:
 
 ### 🖥️ Local Testing
 
-1. Copy `lacale-api.yml` to Prowlarr's custom definitions folder:
+1. Copy `lacale-api-custom.yml` to Prowlarr's custom definitions folder:
    - **Linux**: `~/.config/Prowlarr/Definitions/Custom/`
    - **Windows**: `%AppData%\Prowlarr\Definitions\Custom\`
    - **Docker**: `/config/Definitions/Custom/`

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -19,7 +19,7 @@
 
 ```
 lacale-prowlarr-indexer/
-├── lacale-api.yml        # 🚢 Main indexer definition
+├── lacale-api-custom.yml # 🚢 Main indexer definition
 ├── README.md             # 📖 User documentation (pirate-themed!)
 ├── CONTRIBUTING.md       # 🤝 Contribution guidelines
 ├── DEVELOPER.md          # 🛠️ This file
@@ -32,7 +32,7 @@ lacale-prowlarr-indexer/
 
 ## 📄 Indexer Definition
 
-### File: `lacale-api.yml`
+### File: `lacale-api-custom.yml`
 
 The indexer uses the Cardigann v11 format for Prowlarr.
 
@@ -40,7 +40,7 @@ The indexer uses the Cardigann v11 format for Prowlarr.
 
 | Section | Purpose |
 |---------|---------|
-| `id` | Unique identifier (`lacale-api`) |
+| `id` | Unique identifier (`lacale-api-custom`) |
 | `name` | Display name in Prowlarr |
 | `description` | Tracker description |
 | `language` | `fr-FR` for French |
@@ -218,7 +218,7 @@ curl "https://la-cale.space/api/external?passkey=YOUR_KEY&q=test"
 
 1. 🔍 Identify the change needed
 2. 🌿 Create a feature branch
-3. ✏️ Modify `lacale-api.yml`
+3. ✏️ Modify `lacale-api-custom.yml`
 4. 🧪 Test thoroughly
 5. 📤 Submit pull request
 

--- a/README.md
+++ b/README.md
@@ -71,13 +71,15 @@
 
 ### Étape 1 — Charger les cartes de navigation
 
-Copiez `lacale-api.yml` dans la cale de Prowlarr :
+Copiez `lacale-api-custom.yml` dans la cale de Prowlarr :
 
 | Plateforme | Destination |
 |:-----------|:------------|
 | 🐧 Linux | `~/.config/Prowlarr/Definitions/Custom/` |
 | 🪟 Windows | `%AppData%\Prowlarr\Definitions\Custom\` |
 | 🐳 Docker | `/config/Definitions/Custom/` |
+
+> **Remarque** : Prowlarr inclut déjà un indexer `lacale-api`. Ce fichier utilise `id: lacale-api-custom` pour éviter le conflit et doit conserver un nom de fichier unique.
 
 ### Étape 2 — Relancer le navire
 
@@ -92,7 +94,7 @@ sudo systemctl restart prowlarr
 ### Étape 3 — Rejoindre l'équipage
 
 1. 🧭 Naviguez vers **Indexers** → **Add Indexer**
-2. 🔎 Cherchez **"La Cale"**
+2. 🔎 Cherchez **"La Cale (API) Custom"**
 3. 🔑 Entrez votre **passkey** (trouvable dans votre profil de marin sur la-cale.space)
 4. ✅ Cliquez **Test** puis **Save**
 

--- a/lacale-api-custom.yml
+++ b/lacale-api-custom.yml
@@ -1,6 +1,6 @@
 ---
-id: lacale-api
-name: La Cale (API)
+id: lacale-api-custom
+name: La Cale (API) Custom
 description: 'La Cale is a French Private Tracker for Movies, TV, Music, Games, Software, Ebooks and XXX'
 language: fr-FR
 type: private

--- a/lacale-api-custom.yml
+++ b/lacale-api-custom.yml
@@ -16,8 +16,6 @@ caps:
     # Video (parent + children)
     - {id: video, cat: Movies, desc: 'Vidéo'}
     - {id: films, cat: Movies, desc: 'Films'}
-    - {id: films-4k, cat: Movies/UHD, desc: 'Films 4K'}
-    - {id: films-hd, cat: Movies/HD, desc: 'Films HD'}
     - {id: animation, cat: Movies, desc: 'Animation'}
     - {id: series, cat: TV, desc: 'Séries TV'}
     - {id: s-ries-hd, cat: TV/HD, desc: 'Séries HD'}
@@ -51,10 +49,10 @@ caps:
     - {id: education, cat: Books/Technical, desc: 'Éducation'}
     # XXX (parent + children, default: false)
     - {id: xxx, cat: XXX, desc: 'XXX', default: false}
-    - {id: xxx-hetero, cat: XXX, desc: 'Hétéro', default: false}
-    - {id: xxx-gay, cat: XXX, desc: 'Gay', default: false}
-    - {id: xxx-lesbien, cat: XXX, desc: 'Lesbien', default: false}
-    - {id: xxx-trans, cat: XXX, desc: 'Trans', default: false}
+    - {id: h-t-ro, cat: XXX, desc: 'Hétéro', default: false}
+    - {id: gay, cat: XXX, desc: 'Gay', default: false}
+    - {id: lesbien, cat: XXX, desc: 'Lesbien', default: false}
+    - {id: trans, cat: XXX, desc: 'Trans', default: false}
     # Other (parent + children)
     - {id: autres, cat: Other/Misc, desc: 'Autres'}
     - {id: divers, cat: Other/Misc, desc: 'Divers'}
@@ -178,9 +176,9 @@ search:
         - name: re_replace
           args: ["(?i)^animations?$", "animation"]
         - name: re_replace
-          args: ["(?i)^films?\\s*4k$", "films-4k"]
+          args: ["(?i)^films?\\s*4k$", "films"]
         - name: re_replace
-          args: ["(?i)^films?\\s*hd$", "films-hd"]
+          args: ["(?i)^films?\\s*hd$", "films"]
         - name: re_replace
           args: ["(?i)^films?$", "films"]
         - name: re_replace
@@ -237,21 +235,21 @@ search:
           args: ["(?i)^e-?books?\\s*[&e]\\s*documents?$", "ebooks-documents"]
         # XXX
         - name: re_replace
-          args: ["(?i)^xxx[\\s-]*h[ée]t[ée]ro$", "xxx-hetero"]
+          args: ["(?i)^xxx[\\s-]*h[ée]t[ée]ro$", "h-t-ro"]
         - name: re_replace
-          args: ["(?i)^xxx[\\s-]*gay$", "xxx-gay"]
+          args: ["(?i)^xxx[\\s-]*gay$", "gay"]
         - name: re_replace
-          args: ["(?i)^xxx[\\s-]*lesbien(ne)?s?$", "xxx-lesbien"]
+          args: ["(?i)^xxx[\\s-]*lesbien(ne)?s?$", "lesbien"]
         - name: re_replace
-          args: ["(?i)^xxx[\\s-]*trans$", "xxx-trans"]
+          args: ["(?i)^xxx[\\s-]*trans$", "trans"]
         - name: re_replace
-          args: ["(?i)^h[ée]t[ée]ro$", "xxx-hetero"]
+          args: ["(?i)^h[ée]t[ée]ro$", "h-t-ro"]
         - name: re_replace
-          args: ["(?i)^gay$", "xxx-gay"]
+          args: ["(?i)^gay$", "gay"]
         - name: re_replace
-          args: ["(?i)^lesbien(ne)?s?$", "xxx-lesbien"]
+          args: ["(?i)^lesbien(ne)?s?$", "lesbien"]
         - name: re_replace
-          args: ["(?i)^trans$", "xxx-trans"]
+          args: ["(?i)^trans$", "trans"]
         - name: re_replace
           args: ["(?i)^xxx$", "xxx"]
         # Other

--- a/lacale-api.yml
+++ b/lacale-api.yml
@@ -76,6 +76,21 @@ settings:
     type: info
     label: About your Passkey
     default: "Your passkey can be found on your <a href=\"https://la-cale.space/profile\" target=\"_blank\">profile page</a>. Never share it!"
+  - name: multilang
+    type: checkbox
+    label: Replace MULTi by another language in release name
+    default: false
+  - name: multilanguage
+    type: select
+    label: Replace MULTi by this language
+    default: FRENCH
+    options:
+      FRENCH: FRENCH
+      MULTi.FRENCH: MULTi.FRENCH
+      ENGLISH: ENGLISH
+      MULTi.ENGLISH: MULTi.ENGLISH
+      VOSTFR: VOSTFR
+      MULTi.VOSTFR: MULTi.VOSTFR
   - name: info_flaresolverr
     type: info_flaresolverr
   - name: info_ratio
@@ -125,8 +140,17 @@ search:
   fields:
     _id:
       selector: guid
-    title:
+    title_normal:
       selector: title
+    title_multilang:
+      text: "{{ .Result.title_normal }}"
+      filters:
+        - name: re_replace
+          args: ["(?i)[\\.](MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))[\\.]", ".{{ .Config.multilanguage }}."]
+        - name: re_replace
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
+    title:
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_normal }}{{ end }}"
     category:
       selector: category
       filters:

--- a/lacale-api.yml
+++ b/lacale-api.yml
@@ -124,8 +124,24 @@ search:
   keywordsfilters:
     - name: trim
     - name: re_replace
-      # Cleans dashes, dots, slashes, exclamation marks and normalizes spaces
-      args: ['[\-\.\/!\s]+', ' ']
+      # Mark CJK so we can detect "CJK-only" queries
+      args: ['[\p{IsHiragana}\p{IsKatakana}\p{IsCJKUnifiedIdeographs}]', '__CJK__']
+    - name: re_replace
+      # If query is only CJK, force no-match
+      args: ['^\s*__CJK__\s*(?:__CJK__\s*)*$', 'nomatch_please_ignore']
+    - name: re_replace
+      # If CJK + year only, force no-match
+      args: ['^\s*__CJK__\s*(?:__CJK__\s*)*(19|20)\d{2}\s*$', 'nomatch_please_ignore']
+    - name: re_replace
+      # If year + CJK only, force no-match
+      args: ['^\s*(19|20)\d{2}\s*__CJK__\s*(?:__CJK__\s*)*$', 'nomatch_please_ignore']
+    - name: re_replace
+      # Remove CJK tokens for mixed queries
+      args: ['\b__CJK__\b', '']
+    - name: re_replace
+      # Normalize multiple spaces after replacements
+      args: ['\s+', ' ']
+    - name: trim
 
   inputs:
     passkey: '{{ .Config.passkey }}'


### PR DESCRIPTION
Fix #29 

- Ajout d’un filtre CJK “safe” pour éviter le bruit quand Radarr lance une recherche avec le titre original
- Les requêtes CJK seules (ou CJK + année) sont neutralisées, les requêtes latines restent intactes

----------------
Fix #26 

- Ajout des réglages multilang/multilanguage pour uniformiser les titres MULTI

